### PR TITLE
fix: reveal action icons on focus for improved accessibility

### DIFF
--- a/components/home/examples.tsx
+++ b/components/home/examples.tsx
@@ -39,7 +39,7 @@ export const Examples = async () => {
             key={name}
             className="group/component relative aspect-4/3 w-full max-w-full shrink-0 grow-0 sm:w-[calc((100%-1px)/2)] md:w-[calc((100%-2px)/3)] lg:w-[calc((100%-3px)/4)]"
           >
-            <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-end p-4 opacity-0 transition-opacity group-hover/component:opacity-100 pointer-coarse:opacity-100">
+            <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-end p-4 opacity-0 transition-opacity group-focus-within/component:opacity-100 group-hover/component:opacity-100 pointer-coarse:opacity-100">
               <div className="flex items-center gap-1.5">
                 <CopyComponent item={item} />
                 <CopyCLICommand


### PR DESCRIPTION
## Summary
This PR addresses an accessibility issue where action buttons (copy icons) were only visible on mouse hover (`group-hover`). This prevented keyboard users from seeing or interacting with these actions when navigating via the `Tab` key.

I've added `group-focus-within/component:opacity-100` to the container to ensure that when any internal element receives focus, the controls become visible, satisfying WCAG accessibility standards for keyboard operability.

## Related issues
None.

## Validation
- [x] `bun run lint`
- [ ] `bun run format` (Skipped: Running format affected 500+ unrelated files. Kept changes focused.)
- [x] `bun run build`
- [ ] `bun run build:registry` if registry files changed (Not required: Registry files were not modified.)
- [x] Manual verification completed

## Checklist
- [x] I kept this PR focused on a single change.
- [x] I performed a self-review before requesting review.
- [ ] I updated docs/examples if behavior changed. (N/A)
- [x] I added screenshots or recordings for visible UI changes.

## Notes
Regarding the `format` check: Running the project's formatter triggered changes across a large number of files unrelated to this fix. To keep this PR focused and maintain a clean diff for review, I have only applied the necessary logic changes.

### Visual Changes (Before vs After)
| Before | After |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/2486c75a-12de-43ae-8ab9-b9a480538279) | ![After](https://github.com/user-attachments/assets/845d2225-f0e8-4e79-b04e-c085baa4df2d) |
