### PR TITLE
fix(sponsors): ensure stats legibility on small screens

### DIFF
--- a/components/home/sponsors/stats.tsx
+++ b/components/home/sponsors/stats.tsx
@@ -43,7 +43,7 @@ export const Stats = () => {
   return (
     <Section
       id="stats"
-      className="bg-border grid grid-cols-2 gap-px p-0! md:grid-cols-2 lg:grid-cols-4"
+      className="bg-border grid grid-cols-1 gap-px p-0! md:grid-cols-2 lg:grid-cols-4"
     >
       {stats.map((stat) => (
         <div


### PR DESCRIPTION
## Summary
Update the `stats` grid layout on the sponsors page to use a single-column layout on mobile devices.

Previously, the two-column layout on small screens caused the statistic labels and values to be truncated with ellipses (dots), preventing users from reading the full data. Switching to `grid-cols-1` provides enough horizontal space for the text to render fully without clipping.

## Related issues
None

## Validation
- [x] `bun run lint`
- [ ] `bun run format`
- [x] `bun run build`
- [ ] `bun run build:registry` if registry files changed
- [x] Manual verification completed

## Checklist
- [x] I kept this PR focused on a single change.
- [x] I performed a self-review before requesting review.
- [ ] I updated docs/examples if behavior changed.
- [x] I added screenshots or recordings for visible UI changes.

## Notes
This change specifically targets the mobile UX, where text legibility was compromised due to restricted container widths.

## Visual Changes (Before vs After)
| Before | After |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/0d2468b4-f877-4994-b20c-7f10c393ef4d) | ![After](https://github.com/user-attachments/assets/958838ea-4a04-4aa5-b9e4-9637290625a1) |
