### PR TITLE
fix(header): resolve layout overflow and improve search bar responsiveness

### DIFF
--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -14,7 +14,7 @@ import { TurbostarterButton } from "@/components/home/sponsors/turbostarter";
 export const Header = () => {
   return (
     <header className="bg-fd-background/80 sticky inset-x-0 top-0 z-40 h-(--header-height) border-b backdrop-blur-sm transition-colors">
-      <div className="container mx-auto flex size-full items-center justify-between px-3 md:px-4">
+      <div className="container mx-auto flex gap-2 size-full items-center justify-between px-3 md:px-4">
         <nav className="flex items-center gap-3">
           <Link
             className={cn(
@@ -28,7 +28,7 @@ export const Header = () => {
           <Links className="hidden gap-1 md:flex" />
         </nav>
 
-        <div className="flex items-center md:gap-2">
+        <div className="flex flex-auto justify-end items-center md:gap-2">
           <Search className="hidden md:flex" />
           <GitHub />
           <TurbostarterButton className="hidden md:flex" />

--- a/components/common/header/search.tsx
+++ b/components/common/header/search.tsx
@@ -14,13 +14,13 @@ export const Search = ({
 
   return (
     <Button
-      className={cn("text-muted-foreground relative min-w-52", className)}
+      className={cn("text-muted-foreground relative max-w-52 min-w-15 w-full shrink", className)}
       onClick={() => setOpenSearch(true)}
       variant="secondary"
       {...props}
     >
       <SearchIcon className="size-4" />
-      <p className="font-normal">Search...</p>
+      <p className="font-normal hidden lg:block">Search...</p>
       <span className="ml-auto flex items-center gap-0.5">
         <Kbd className="bg-background border">⌘</Kbd>
         <Kbd className="bg-background border">K</Kbd>


### PR DESCRIPTION
## Summary
This PR fixes a horizontal scrollbar and layout-breaking issue occurring between `768px` and `868px`.

## Changes:
- Added `gap-2` to the header wrapper for consistent spacing.
- Updated the right-side wrapper with `flex-auto` and `justify-end` to ensure it correctly occupies available space and aligns to the right.
- Refactored the Search component:
  - Applied `max-w-52`, `min-w-22`, and `w-full` with `shrink` to allow the bar to resize fluidly.
  - Hidden the "Search..." text on medium screens (`hidden lg:block`) to save horizontal space, preventing it from pushing other navigation elements.

## Related issues
None

## Validation
- [x] `bun run lint`
- [ ] `bun run format`
- [x] `bun run build`
- [ ] `bun run build:registry` if registry files changed
- [x] Manual verification completed

## Checklist
- [x] I kept this PR focused on a single change.
- [x] I performed a self-review before requesting review.
- [ ] I updated docs/examples if behavior changed.
- [x] I added screenshots or recordings for visible UI changes.

## Notes
The search bar now gracefully transitions from a full-width input style to a more compact icon-focused button as the viewport shrinks, eliminating the need for a horizontal scrollbar.

## Visual Changes (Before vs After)
| Before | After |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/3ccca1b9-dff9-42be-9c71-dc86f3b1752a) | ![After](https://github.com/user-attachments/assets/285165a8-2021-46ff-8bbf-65b8c597bda1) |