### PR TITLE
Fix TurboStarter link in footer

### DIFF
--- a/components/common/footer.tsx
+++ b/components/common/footer.tsx
@@ -1,5 +1,4 @@
-import { TURBOSTARTER_URL } from "@/components/home/sponsors/turbostarter";
-import { X_USERNAME } from "@/lib/constants";
+import { TURBOSTARTER_URL, X_USERNAME } from "@/lib/constants";
 
 export const Footer = () => {
   return (
@@ -7,7 +6,7 @@ export const Footer = () => {
       <p className="text-muted-foreground text-sm">
         Made with ❤️ and{" "}
         <a
-          href={`${TURBOSTARTER_URL}?utm_source=loading-ui&utm_medium=referral`}
+          href={`${TURBOSTARTER_URL}&utm_source=loading-ui&utm_medium=referral`}
           target="_blank"
           rel="noreferrer"
           className="text-primary underline"

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -14,7 +14,7 @@ import { TurbostarterButton } from "@/components/home/sponsors/turbostarter";
 export const Header = () => {
   return (
     <header className="bg-fd-background/80 sticky inset-x-0 top-0 z-40 h-(--header-height) border-b backdrop-blur-sm transition-colors">
-      <div className="container mx-auto flex gap-2 size-full items-center justify-between px-3 md:px-4">
+      <div className="container mx-auto flex size-full items-center justify-between gap-2 px-3 md:px-4">
         <nav className="flex items-center gap-3">
           <Link
             className={cn(
@@ -28,7 +28,7 @@ export const Header = () => {
           <Links className="hidden gap-1 md:flex" />
         </nav>
 
-        <div className="flex flex-auto justify-end items-center md:gap-2">
+        <div className="flex flex-auto items-center justify-end md:gap-2">
           <Search className="hidden md:flex" />
           <GitHub />
           <TurbostarterButton className="hidden md:flex" />

--- a/components/common/header/mobile-nav.tsx
+++ b/components/common/header/mobile-nav.tsx
@@ -78,7 +78,7 @@ export function MobileNav({
         sideOffset={14}
       >
         <div className="flex flex-col gap-10 overflow-auto p-5">
-          <TurboStarterMobileNavCta className="-mt-2 -mb-4 -mx-2" />
+          <TurboStarterMobileNavCta className="-mx-2 -mt-2 -mb-4" />
 
           <div className="flex flex-col gap-4">
             <div className="text-muted-foreground text-sm font-medium">
@@ -100,7 +100,7 @@ export function MobileNav({
               Sections
             </div>
             <div className="flex flex-col gap-3">
-              {topLevelPages.map(item => {
+              {topLevelPages.map((item) => {
                 return (
                   <MobileLink
                     key={item.url}
@@ -120,7 +120,7 @@ export function MobileNav({
             </div>
           </div>
           <div className="flex flex-col gap-8">
-            {tree?.children?.map(group => {
+            {tree?.children?.map((group) => {
               if (EXCLUDED_SECTIONS.has(group.$id ?? "")) {
                 return null;
               }
@@ -137,7 +137,7 @@ export function MobileNav({
                     {group.name}
                   </div>
                   <div className="flex flex-col gap-3">
-                    {pages.map(item => {
+                    {pages.map((item) => {
                       if (EXCLUDED_PAGES.has(item.url)) {
                         return null;
                       }

--- a/components/common/header/search.tsx
+++ b/components/common/header/search.tsx
@@ -14,13 +14,16 @@ export const Search = ({
 
   return (
     <Button
-      className={cn("text-muted-foreground relative max-w-52 min-w-15 w-full shrink", className)}
+      className={cn(
+        "text-muted-foreground relative w-full max-w-52 min-w-15 shrink",
+        className,
+      )}
       onClick={() => setOpenSearch(true)}
       variant="secondary"
       {...props}
     >
       <SearchIcon className="size-4" />
-      <p className="font-normal hidden lg:block">Search...</p>
+      <p className="hidden font-normal lg:block">Search...</p>
       <span className="ml-auto flex items-center gap-0.5">
         <Kbd className="bg-background border">⌘</Kbd>
         <Kbd className="bg-background border">K</Kbd>

--- a/components/home/sponsors/turbostarter.tsx
+++ b/components/home/sponsors/turbostarter.tsx
@@ -2,17 +2,16 @@
 
 import { Icons } from "@/components/common/icons";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { TURBOSTARTER_URL } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { track } from "@vercel/analytics";
-
-export const TURBOSTARTER_URL = "https://www.turbostarter.dev?ref=loading-ui";
 
 export const TurbostarterButton = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLAnchorElement>) => (
   <a
-    href={`${TURBOSTARTER_URL}?utm_source=loading-ui&utm_medium=referral`}
+    href={`${TURBOSTARTER_URL}&utm_source=loading-ui&utm_medium=referral`}
     target="_blank"
     className={cn(
       "border-border text-foreground hover:bg-accent flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
@@ -43,7 +42,7 @@ export function TurbostarterSidebarCta({
       )}
       {...props}
     >
-      <p className="text-base leading-tight tracking-tight font-semibold text-balance underline-offset-2 group-hover:underline">
+      <p className="text-base leading-tight font-semibold tracking-tight text-balance underline-offset-2 group-hover:underline">
         Build your SaaS in days, not months. On all platforms.
       </p>
       <p className="text-muted-foreground">
@@ -57,7 +56,7 @@ export function TurbostarterSidebarCta({
         Try TurboStarter
       </Button>
       <a
-        href={`${TURBOSTARTER_URL}?utm_source=loading-ui&utm_medium=referral`}
+        href={`${TURBOSTARTER_URL}&utm_source=loading-ui&utm_medium=referral`}
         target="_blank"
         className="absolute inset-0"
         onClick={() =>
@@ -79,7 +78,7 @@ export const TurboStarterMobileNavCta = ({
 }: React.ComponentProps<"a">) => {
   return (
     <a
-      href={`${TURBOSTARTER_URL}?utm_source=loading-ui&utm_medium=referral`}
+      href={`${TURBOSTARTER_URL}&utm_source=loading-ui&utm_medium=referral`}
       target="_blank"
       onClick={() =>
         track("sponsor_clicked", {
@@ -88,12 +87,12 @@ export const TurboStarterMobileNavCta = ({
         })
       }
       className={cn(
-        "group bg-surface text-surface-foreground relative flex flex-col gap-2 p-5 rounded-md text-sm",
+        "group bg-surface text-surface-foreground relative flex flex-col gap-2 rounded-md p-5 text-sm",
         className,
       )}
       {...props}
     >
-      <p className="text-base leading-tight tracking-tight font-semibold text-balance underline-offset-2 group-hover:underline">
+      <p className="text-base leading-tight font-semibold tracking-tight text-balance underline-offset-2 group-hover:underline">
         Build your SaaS in days, not months. On all platforms.
       </p>
       <p className="text-muted-foreground">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,5 @@
+export const TURBOSTARTER_URL = "https://www.turbostarter.dev?ref=loading-ui";
+
 export const GITHUB_URL = "https://github.com/turbostarter/loading-ui";
 export const EMAIL = "hello@turbostarter.dev";
 export const X_USERNAME = "bzagrodzki";


### PR DESCRIPTION
## Summary

Fixed TurboStarter links that broke in the footer by moving TURBOSTARTER_URL into lib/constants (so server components don’t treat it as a client reference) and appending UTM params with & because the base URL already includes ?ref=….

Previously led to a 404

## Validation

- [x] `bun run lint`
- [x] `bun run format`
- [x] `bun run build`
- [ ] `bun run build:registry` if registry files changed
- [x] Manual verification completed

## Checklist

- [x] I kept this PR focused on a single change.
- [x] I performed a self-review before requesting review.
- [ ] I updated docs/examples if behavior changed.
- [x] I added screenshots or recordings for visible UI changes.

## Demo
Before:
https://github.com/user-attachments/assets/5

After:
https://github.com/user-attachments/assets/4628f268-95b7-407e-82ad-2a16909bb433


