### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Loading UI is a single **Next.js 16 (App Router, Turbopack)** app — a docs site plus an
+installable component registry for spinners/loaders. There is no separate backend; the
+dev server serves everything.
+
+### Package manager: Bun (not pnpm)
+
+This repo uses **Bun** for package management and all scripts (see `.github/CONTRIBUTING.md`
+and `.github/setup/action.yml`). A `pnpm-lock.yaml` is also checked in, but it is **not** the
+source of truth — always use `bun`, not `pnpm`/`npm`. Bun is preinstalled at `~/.bun/bin/bun`
+and the update script runs `bun install`.
+
+### Generated files (do not hand-edit)
+
+`bun install` runs a `postinstall` step (and `dev` runs `predev`) that regenerates:
+- `.source/` — Fumadocs MDX output (`fumadocs-mdx`), gitignored.
+- `app/colors.css` and `lib/colors.ts` — produced by `bun run build:colors`.
+
+These are recreated automatically; don't edit them by hand. After changing registry sources,
+regenerate artifacts with `bun run build:registry`.
+
+### Commands (run from repo root)
+
+Standard scripts live in `package.json` / `.github/CONTRIBUTING.md`:
+- Run (dev): `bun run dev` → http://localhost:3000 (key routes: `/`, `/docs`, `/docs/components/<name>`).
+- Lint: `bun run lint` (oxlint).
+- Format: `bun run format` (oxfmt `--check`); `bun run format:fix` to apply.
+- Build: `bun run build` (runs `build:colors` then `next build`).
+
+### Gotchas
+
+- `bun install` may report `bun.lock` as modified (Bun-version drift); the update script uses a
+  non-frozen `bun install` so this is expected. Don't commit the regenerated `bun.lock` unless
+  you intend to bump it.
+- `bun run format` currently fails on a clean checkout due to **pre-existing** formatting issues
+  in a few committed files (e.g. `components/common/header/search.tsx`, `lib/registry.ts`). This
+  is a repo-state issue, not an environment problem — don't "fix" unrelated files unless asked.
+- First page compile under Turbopack is slow (~10s for `/`); subsequent loads are fast.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for this Next.js (Loading UI) app and documents non-obvious setup details for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the Bun-based workflow, generated files, standard commands, and gotchas.
- No application code changes.

## Environment

- **Package manager / runtime:** Bun `1.3.14` (installed via official installer; not pnpm/npm despite the checked-in `pnpm-lock.yaml`).
- **Update script:** `bun install` (non-frozen; runs `postinstall` which regenerates `.source/`, `app/colors.css`, `lib/colors.ts`).
- **Dev server:** `bun run dev` → http://localhost:3000.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Install | `bun install` | ✅ 670 packages |
| Lint | `bun run lint` | ✅ clean |
| Build | `bun run build` | ✅ 171 static pages |
| Run | `bun run dev` | ✅ HTTP 200 on `/` and `/docs` |
| Format | `bun run format` | ⚠️ pre-existing format issues in 5 committed files (repo state, not env) |

### Walkthrough

Manually verified the running app end-to-end: homepage with animated loaders, docs site, a loader component page with a live preview, and interactive install-command tabs + copy button.

[loading_ui_dev_walkthrough.mp4](https://cursor.com/agents/bc-7dd9ee5f-0f27-4c4c-add9-78178e20a7e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Floading_ui_dev_walkthrough.mp4)

[Homepage with animated loaders](https://cursor.com/agents/bc-7dd9ee5f-0f27-4c4c-add9-78178e20a7e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaders.webp)
[Classic component page with live preview](https://cursor.com/agents/bc-7dd9ee5f-0f27-4c4c-add9-78178e20a7e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclassic_component_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dd9ee5f-0f27-4c4c-add9-78178e20a7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dd9ee5f-0f27-4c4c-add9-78178e20a7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

